### PR TITLE
Pingu: Fix Idat writing performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,130 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = namespaces,types,methods
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:suggestion
+
+# use language keywords instead of BCL types
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Code style defaults
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:none
+csharp_style_expression_bodied_constructors = true:none
+csharp_style_expression_bodied_operators = true:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat, ps1}]
+end_of_line = crlf

--- a/src/Pingu/Checksums/Adler32.cs
+++ b/src/Pingu/Checksums/Adler32.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Pingu.Checksums
@@ -9,20 +8,9 @@ namespace Pingu.Checksums
         const int Adler32Modulus = 65521;
         const int NMax = 5552;
 
-        uint a = 1, b = 0;
+        uint a = 1, b;
 
         public int Hash => unchecked((int)((b << 16) | a));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe void Do16(byte* buf, ref uint a, ref uint b) { Do8(buf, 0, ref a, ref b); Do8(buf, 8, ref a, ref b); }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe void Do8(byte* buf, int i, ref uint a, ref uint b) { Do4(buf, i, ref a, ref b); Do4(buf, i + 4, ref a, ref b); }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe void Do4(byte* buf, int i, ref uint a, ref uint b) { Do2(buf, i, ref a, ref b); Do2(buf, i + 2, ref a, ref b); }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe void Do2(byte* buf, int i, ref uint a, ref uint b) { Do1(buf, i, ref a, ref b); Do1(buf, i + 1, ref a, ref b); }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe void Do1(byte* buf, int i, ref uint a, ref uint b) { a += buf[i]; b += a; }
 
         // See Adler32Implementation in the benchmarks suite. This is the best implementation
         // on RyuJIT and Mono, and not far behind on the legacy 64-bit JIT. It relies on the fact that
@@ -35,12 +23,44 @@ namespace Pingu.Checksums
         {
             fixed (byte* ptr = data) {
                 byte* buf = ptr + offset;
-                int chunkSize;
                 while (length > 0) {
-                    chunkSize = length < NMax ? length : NMax;
+                    var chunkSize = length < NMax ? length : NMax;
                     length -= chunkSize;
                     while (chunkSize >= 16) {
-                        Do16(buf, ref a, ref b);
+                        // This is a hand-unrolled 16 byte loop. Do not touch.
+                        a += buf[0];
+                        b += a;
+                        a += buf[1];
+                        b += a;
+                        a += buf[2];
+                        b += a;
+                        a += buf[3];
+                        b += a;
+                        a += buf[4];
+                        b += a;
+                        a += buf[5];
+                        b += a;
+                        a += buf[6];
+                        b += a;
+                        a += buf[7];
+                        b += a;
+                        a += buf[8];
+                        b += a;
+                        a += buf[9];
+                        b += a;
+                        a += buf[10];
+                        b += a;
+                        a += buf[11];
+                        b += a;
+                        a += buf[12];
+                        b += a;
+                        a += buf[13];
+                        b += a;
+                        a += buf[14];
+                        b += a;
+                        a += buf[15];
+                        b += a;
+                        // End hand-unrolled loop.
                         buf += 16;
                         chunkSize -= 16;
                     }


### PR DESCRIPTION
2 pieces: One, fix Adler32 performance by hand-unrolling the loop rather than playing a game of will it/won't it with the inliner, and two, squeeze a little more speed out by delaying DEFLATE and ADLER32 work until all the scanlines are computed.